### PR TITLE
Fix an issue when using ftw.gopip in combination with versions fromProducts.CMFEditions.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix an issue when using ftw.gopip in combination with versions from
+  Products.CMFEditions.
+  [elioschmutz]
 
 
 1.0.0 (2016-09-26)

--- a/ftw/gopip/ordering.py
+++ b/ftw/gopip/ordering.py
@@ -1,4 +1,3 @@
-from Acquisition import aq_base
 from functools import partial
 from plone import api
 from plone.folder.default import DefaultOrdering
@@ -53,19 +52,28 @@ class KeepIndexInSync(object):
     def ensure_children_position_updated_in_index(self):
         catalog = api.portal.get_tool('portal_catalog')
 
-        # Fix an issue when using ftw.gopip in combination with versions from
-        # Products.CMFEditions.
-        #
-        # In some cases we get an ImplicitAcquisitionWrapper-object as
-        # the context which will cause errors when accessing
-        # object-methods. To fix the issue, we have to get the real
-        # content object.
-        #
-        # Warning: this case is not testet!
-        context = aq_base(self.context)
+        try:
+            path = '/'.join(self.context.getPhysicalPath())
+        except AttributeError:
+            # Fix an issue when using ftw.gopip in combination with versions
+            # from Products.CMFEditions.
+            #
+            # Retrieve an old version will replace and remove current object
+            # attributes which will fire the ordering event. In this case we
+            # get an acquisition wrapped object whos parent is an
+            # ObjectManagerStorageAdapter from CMFEditions.
+            #
+            # Accessing acquisition-methods on the object like getPhysicalPath
+            # will cause an error because its parent, the
+            # ObjectManagerStorageAdapter, has no such method.
+            #
+            # Unfortuately there is no other way to check if the object is
+            # such a wrapped object or not.
+            #
+            # Warning: this case is not testet!
+            return
 
         index = catalog._catalog.getIndex('getObjPositionInParent')
-        path = '/'.join(context.getPhysicalPath())
         child_ids_to_index = []
 
         for position, child_id in enumerate(self.idsInOrder()):
@@ -81,7 +89,7 @@ class KeepIndexInSync(object):
                 child_ids_to_index.append(child_id)
 
         for child_id in child_ids_to_index:
-            child_object = context[child_id]
+            child_object = self.context[child_id]
             catalog.reindexObject(child_object,
                                   idxs=['getObjPositionInParent'],
                                   update_metadata=False)


### PR DESCRIPTION
By getting the `aq_base` of the current context, we can fix the ImplicitAcquisitionWrapper-object.

fixes #1 

